### PR TITLE
fix: allow duplicate keys

### DIFF
--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"slices"
 	"strings"
 	"time"
 
@@ -91,7 +90,6 @@ func (w *Workflow) workflowBuilder(tasks *model.TaskList, name string) ([]*Tempo
 		Tasks:     make([]TemporalWorkflowTask, 0),
 		Timeout:   timeout,
 	}
-	existingKeys := make([]string, 0)
 
 	// Iterate over the task list to build out our workflow(s)
 	for _, item := range *tasks {
@@ -99,12 +97,6 @@ func (w *Workflow) workflowBuilder(tasks *model.TaskList, name string) ([]*Tempo
 		var taskType string
 		var err error
 		var additionalWorkflows []*TemporalWorkflow
-
-		// Check for duplicate keys
-		if _, found := slices.BinarySearch(existingKeys, item.Key); found {
-			return nil, fmt.Errorf("%w: %s", ErrDuplicateKey, item.Key)
-		}
-		existingKeys = append(existingKeys, item.Key)
 
 		if http := item.AsCallHTTPTask(); http != nil {
 			task = httpTaskImpl(http, item.Key)


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->
Having used it for a bit, duplicate keys make sense especially as they're not used by Temporal, especially if you're doing multiple `wait` tasks - having to think up a unique name for each is a pain in the arse

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
