### PR TITLE
fix: change the tasks to return the value rather

### DIFF
--- a/pkg/dsl/taskCallHTTP.go
+++ b/pkg/dsl/taskCallHTTP.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -174,22 +173,20 @@ func (a *activities) CallHTTP(ctx context.Context, callHttp *model.CallHTTP, var
 func httpTaskImpl(task *model.CallHTTP, key string) TemporalWorkflowFunc {
 	var a *activities
 
-	return func(ctx workflow.Context, data *Variables, output map[string]OutputType) error {
+	return func(ctx workflow.Context, data *Variables, output map[string]OutputType) (map[string]OutputType, error) {
 		logger := workflow.GetLogger(ctx)
 		logger.Debug("Calling HTTP endpoint")
 
 		var result CallHTTPResult
 		if err := workflow.ExecuteActivity(ctx, a.CallHTTP, task, data).Get(ctx, &result); err != nil {
-			return fmt.Errorf("error calling http task: %w", err)
+			return nil, fmt.Errorf("error calling http task: %w", err)
 		}
 
-		maps.Copy(output, map[string]OutputType{
+		return map[string]OutputType{
 			key: {
 				Type: CallHTTPResultType,
 				Data: result,
 			},
-		})
-
-		return nil
+		}, nil
 	}
 }

--- a/pkg/dsl/taskSet.go
+++ b/pkg/dsl/taskSet.go
@@ -106,18 +106,17 @@ func setTaskInterpolate(ctx workflow.Context, keyID, input any, data *Variables)
 }
 
 func setTaskImpl(task *model.SetTask) TemporalWorkflowFunc {
-	return func(ctx workflow.Context, data *Variables, output map[string]OutputType) error {
+	return func(ctx workflow.Context, data *Variables, output map[string]OutputType) (map[string]OutputType, error) {
+		out := make(map[string]OutputType)
 		for key, value := range task.Set {
-			var err error
-
-			value, err = setTaskInterpolate(ctx, key, value, data)
+			parsedValue, err := setTaskInterpolate(ctx, key, value, data)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
-			data.Data[key] = value
+			data.Data[key] = parsedValue
 		}
 
-		return nil
+		return out, nil
 	}
 }

--- a/pkg/dsl/taskWait.go
+++ b/pkg/dsl/taskWait.go
@@ -24,7 +24,7 @@ import (
 )
 
 func waitTaskImpl(task *model.WaitTask) TemporalWorkflowFunc {
-	return func(ctx workflow.Context, data *Variables, output map[string]OutputType) error {
+	return func(ctx workflow.Context, data *Variables, output map[string]OutputType) (map[string]OutputType, error) {
 		logger := workflow.GetLogger(ctx)
 
 		duration := ToDuration(task.Wait)
@@ -32,9 +32,9 @@ func waitTaskImpl(task *model.WaitTask) TemporalWorkflowFunc {
 		logger.Debug("Sleeping", "duration", duration.String())
 
 		if err := workflow.Sleep(ctx, duration); err != nil {
-			return fmt.Errorf("error sleeping: %w", err)
+			return nil, fmt.Errorf("error sleeping: %w", err)
 		}
 
-		return nil
+		return nil, nil
 	}
 }

--- a/pkg/dsl/workflow.go
+++ b/pkg/dsl/workflow.go
@@ -36,7 +36,7 @@ type TemporalWorkflowTask struct {
 	Task     TemporalWorkflowFunc
 }
 
-type TemporalWorkflowFunc func(ctx workflow.Context, data *Variables, output map[string]OutputType) error
+type TemporalWorkflowFunc func(ctx workflow.Context, data *Variables, output map[string]OutputType) (map[string]OutputType, error)
 
 type TemporalWorkflow struct {
 	EnvPrefix string
@@ -122,8 +122,12 @@ func (t *TemporalWorkflow) Workflow(ctx workflow.Context, input HTTPData) (map[s
 		}
 
 		logger.Info("Running task", "name", task.Key)
-		if err := task.Task(ctx, vars, output); err != nil {
+		resp, err := task.Task(ctx, vars, output)
+		if err != nil {
 			return nil, err
+		}
+		if resp != nil {
+			maps.Copy(output, resp)
 		}
 	}
 

--- a/toodaloo.md
+++ b/toodaloo.md
@@ -4,8 +4,8 @@
 
 | File | Line Number | Author | Message |
 | --- | --- | --- | --- |
-| [pkg/dsl/taskCallHTTP.go](pkg/dsl/taskCallHTTP.go#L105) | 105 | Simon Emms <simon@simonemms.com> | configure the timeout |
-| [pkg/dsl/taskFork.go](pkg/dsl/taskFork.go#L32) | 32 | Simon Emms <simon@simonemms.com> | handle competing forks |
+| [pkg/dsl/taskCallHTTP.go](pkg/dsl/taskCallHTTP.go#L104) | 104 | Simon Emms <simon@simonemms.com> | configure the timeout |
+| [pkg/dsl/taskFork.go](pkg/dsl/taskFork.go#L31) | 31 | Simon Emms <simon@simonemms.com> | handle competing forks |
 | [pkg/dsl/taskListen.go](pkg/dsl/taskListen.go#L86) | 86 | Simon Emms <simon@simonemms.com> | allow data to be received via signal |
 | [pkg/dsl/taskListen.go](pkg/dsl/taskListen.go#L87) | 87 | Simon Emms <simon@simonemms.com> | ignore if timeout is set to 0 or "0" |
 | [pkg/dsl/taskListen.go](pkg/dsl/taskListen.go#L246) | 246 | Simon Emms <simon@simonemms.com> | figure out a way of customising the timeout |


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Previously, the task functions (in Temporalland, the workflows) set the data ambiently. This had the side effect of potentially breaking replays or runs on other instances.

This fixes that oversight.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
