### PR TITLE
feat: use the namespace property to set task queue

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,6 @@ var rootOpts struct {
 	LogLevel             string
 	MetricsListenAddress string
 	MetricsPrefix        string
-	TaskQueue            string
 	TemporalAddress      string
 	TemporalAPIKey       string
 	TemporalTLSEnabled   bool
@@ -134,10 +133,14 @@ var rootCmd = &cobra.Command{
 			log.Trace().Msg("Temporal connection closed")
 		}()
 
-		log.Debug().Msg("Starting health check service")
-		temporal.NewHealthCheck(context.Background(), rootOpts.TaskQueue, rootOpts.HealthListenAddress, client)
+		taskQueue := workflowDefinition.Document.Namespace
 
-		temporalWorker := worker.New(client, rootOpts.TaskQueue, worker.Options{})
+		log.Debug().Msg("Starting health check service")
+		temporal.NewHealthCheck(context.Background(), taskQueue, rootOpts.HealthListenAddress, client)
+
+		log.Info().Str("task-queue", taskQueue).Msg("Starting workflow")
+
+		temporalWorker := worker.New(client, taskQueue, worker.Options{})
 
 		if err := dsl.NewWorkflow(temporalWorker, workflowDefinition); err != nil {
 			return gh.FatalError{
@@ -211,12 +214,6 @@ func init() {
 	rootCmd.Flags().StringVar(
 		&rootOpts.MetricsPrefix, "metrics-prefix",
 		viper.GetString("metrics_prefix"), "Prefix for metrics",
-	)
-
-	viper.SetDefault("task_queue", "temporal-dsl")
-	rootCmd.Flags().StringVarP(
-		&rootOpts.TaskQueue, "task-queue", "q",
-		viper.GetString("task_queue"), "Task queue name",
 	)
 
 	viper.SetDefault("temporal_address", client.DefaultHostPort)

--- a/examples/basic/workflow.yaml
+++ b/examples/basic/workflow.yaml
@@ -2,7 +2,7 @@
 # translated into a Temporal workflow
 document:
   dsl: 1.0.0
-  namespace: ignored # Ignored by Temporal
+  namespace: temporal-dsl # Mapped to the task queue
   name: basic # Workflow name
   version: 0.0.1
   title: Basic Workflow

--- a/workflow.example.yaml
+++ b/workflow.example.yaml
@@ -2,7 +2,7 @@
 # translated into a Temporal workflow
 document:
   dsl: 1.0.0
-  namespace: ignored # Ignored by Temporal
+  namespace: temporal-dsl # Mapped to the task queue
   name: example # Workflow name
   version: 0.0.1
   title: Example Workflow


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Although Serverless Workflow calls it "namespace", which Temporal has its own definition of, it's really a way of isolating the things that run a task. This is what Temporal's task queue names do - a way of running different collections of workflows.

Temporal namespaces are a way of isolating connections, which is not really what we're doing with SW's namespace property.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
