### PR TITLE
fix: update the output to follow the serverless workflow standard

### DIFF
--- a/examples/basic/workflow.yaml
+++ b/examples/basic/workflow.yaml
@@ -23,8 +23,9 @@ timeout:
     minutes: 1
 do:
   - baseData:
-      export:
-        as: data
+      # output:
+      #   as:
+      #     data: ${ . }
       set:
         # Set a variable from an envvar
         envvar: ${ .env.EXAMPLE_ENVVAR }
@@ -36,46 +37,46 @@ do:
         array:
           - ${ uuid }
           - hello: world
-  - wait:
-      wait:
-        seconds: 5
-  - getUser:
-      call: http
-      export:
-        as: getUser
-      with:
-        method: get
-        endpoint: ${ "https://jsonplaceholder.typicode.com/users/" + (.input.userId | tostring) }
-  - raiseAlarm:
-      # A fork is a series of child workflows running in parallel
-      export:
-        as: raiseAlarm
-      fork:
-        # If not competing, all tasks will run to the finish - this is the default behaviour
-        compete: false
-        branches:
-          # A single step is passed in by the Serverless Workflow task
-          - callNurse:
-              call: http
-              export:
-                as: callNurse
-              with:
-                method: get
-                endpoint: https://jsonplaceholder.typicode.com/users/2
-          # Multiple steps can be passed in by the Serverless Workflow do task
-          - multiStep:
-              do:
-                - wait1:
-                    wait:
-                      seconds: 3
-                - wait2:
-                    wait:
-                      seconds: 2
-          # Another single step child workflow
-          - callDoctor:
-              call: http
-              export:
-                as: callDoctor
-              with:
-                method: get
-                endpoint: ${ "https://jsonplaceholder.typicode.com/users/" + (.input.userId | tostring) }
+  # - wait:
+  #     wait:
+  #       seconds: 5
+  # - getUser:
+  #     call: http
+  #     export:
+  #       as: getUser
+  #     with:
+  #       method: get
+  #       endpoint: ${ "https://jsonplaceholder.typicode.com/users/" + (.input.userId | tostring) }
+  # - raiseAlarm:
+  #     # A fork is a series of child workflows running in parallel
+  #     export:
+  #       as: raiseAlarm
+  #     fork:
+  #       # If not competing, all tasks will run to the finish - this is the default behaviour
+  #       compete: false
+  #       branches:
+  #         # A single step is passed in by the Serverless Workflow task
+  #         - callNurse:
+  #             call: http
+  #             export:
+  #               as: callNurse
+  #             with:
+  #               method: get
+  #               endpoint: https://jsonplaceholder.typicode.com/users/2
+  #         # Multiple steps can be passed in by the Serverless Workflow do task
+  #         - multiStep:
+  #             do:
+  #               - wait1:
+  #                   wait:
+  #                     seconds: 3
+  #               - wait2:
+  #                   wait:
+  #                     seconds: 2
+  #         # Another single step child workflow
+  #         - callDoctor:
+  #             call: http
+  #             export:
+  #               as: callDoctor
+  #             with:
+  #               method: get
+  #               endpoint: ${ "https://jsonplaceholder.typicode.com/users/" + (.input.userId | tostring) }

--- a/pkg/utils/state.go
+++ b/pkg/utils/state.go
@@ -19,11 +19,8 @@ package utils
 import (
 	"context"
 	"maps"
-	"strings"
 
-	"github.com/rs/zerolog/log"
 	swUtils "github.com/serverlessworkflow/sdk-go/v3/impl/utils"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/workflow"
 )
@@ -32,7 +29,7 @@ type State struct {
 	Data   map[string]any `json:"data"`            // Data stored along the way
 	Env    map[string]any `json:"env"`             // Available environment variables
 	Input  any            `json:"input,omitempty"` // The input given by the caller
-	Output map[string]any `json:"output"`          // What will be output to the caller
+	Output any            `json:"output"`          // What will be output to the caller
 }
 
 func (s *State) init() *State {
@@ -42,31 +39,12 @@ func (s *State) init() *State {
 	if s.Data == nil {
 		s.Data = map[string]any{}
 	}
-	if s.Output == nil {
-		s.Output = map[string]any{}
-	}
 
 	return s
 }
 
 func (s *State) AddData(data map[string]any) *State {
 	maps.Copy(s.Data, data)
-
-	return s
-}
-
-func (s *State) AddOutput(task model.Task, output any) *State {
-	if output != nil {
-		if export := task.GetBase().Export; export != nil {
-			if exportAs := export.As; exportAs != nil {
-				// Trim runtime expression wrapper
-				key := strings.Trim(exportAs.String(), "{}")
-				log.Debug().Any("key", key).Msg("Add task output to state")
-
-				s.Output[key] = output
-			}
-		}
-	}
 
 	return s
 }
@@ -143,7 +121,7 @@ func (s *State) AddWorkflowInfo(ctx workflow.Context) *State {
 }
 
 func (s *State) ClearOutput() *State {
-	s.Output = map[string]any{}
+	s.Output = nil
 	return s
 }
 
@@ -153,7 +131,7 @@ func (s *State) Clone() *State {
 	s1.Data = swUtils.DeepClone(s.Data)
 	s1.Env = swUtils.DeepClone(s.Env)
 	s1.Input = swUtils.DeepCloneValue(s.Input)
-	s1.Output = swUtils.DeepClone(s.Output)
+	s1.Output = swUtils.DeepCloneValue(s.Output)
 
 	return s1
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This has changed the output/export to what Serverless Workflow intended. This is pretty poorly documented, so I misunderstood it at first.

The basic idea is that the last task defaults it's own output as the response - eg, if you have a `set` task, it returns that or, if you have a `callHttp` task, it returns the result.

If you want to combine things, you need to `export` it to the `$context` and then merge it

```yaml
do:
  - data:
      set:
        envvar: ${ $env.EXAMPLE_ENVVAR }
        uuid: ${ uuid }
```

This will output `{ "envvar": "<envvar value>", "uuid": "<some uuid>" }`


```yaml
do:
  - data:
      set:
        envvar: ${ $env.EXAMPLE_ENVVAR }
        uuid: ${ uuid }
  - data1:
      set:
        hello: world 
```

This will output `{ "hello": "world" }`

```yaml
do:
  - data:
      set:
        envvar: ${ $env.EXAMPLE_ENVVAR }
        uuid: ${ uuid }
      export:
        # This sets the data to `$context.data`
        as:
          data: ${ . }
  - data1:
      set:
        hello: world 
      output:
        # This merges all the data in the `$context` with the data set here
        as: '${ $context + { "data1": . } }'
```

This will output `{ "data": { "envvar": "<envvar value>", "uuid": "<some uuid>" }, "data1": { "hello": "world" } }`

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
