### PR TITLE
fix: dont let timer go forever

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,8 @@
 # See scripts/generate-authors.sh to make modifications.
 
 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Dimsi <dimosh3k@gmail.com>
+Hynek <dimosh3k@gmail.com>
 Maciek Bryński <maciek@brynski.pl>
 mrsimonemms <275848+mrsimonemms@users.noreply.github.com>
 Simon Emms <simon@simonemms.com>

--- a/pkg/zigflow/tasks/task_builder_listen.go
+++ b/pkg/zigflow/tasks/task_builder_listen.go
@@ -97,6 +97,7 @@ func (t *ListenTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 
 		var cancel workflow.CancelFunc
 		ctx, cancel = workflow.WithCancel(ctx)
+		defer cancel()
 
 		for i, event := range events {
 			if isAll {

--- a/toodaloo.md
+++ b/toodaloo.md
@@ -5,4 +5,4 @@
 | File | Line Number | Author | Message |
 | --- | --- | --- | --- |
 | [pkg/zigflow/activities/run.go](pkg/zigflow/activities/run.go#L46) | 46 | Simon Emms <simon@simonemms.com> | in addition to Docker #181 |
-| [pkg/zigflow/tasks/task_builder_listen.go](pkg/zigflow/tasks/task_builder_listen.go#L323) | 323 | Simon Emms <simon@simonemms.com> | configure the "until" EventConsumptionUntil for "any" events |
+| [pkg/zigflow/tasks/task_builder_listen.go](pkg/zigflow/tasks/task_builder_listen.go#L324) | 324 | Simon Emms <simon@simonemms.com> | configure the "until" EventConsumptionUntil for "any" events |


### PR DESCRIPTION
## Description

There is a forgotten ctx in the `listen` task builder where the context was not being correctly cancelled after the task completed or timed out.

## How to test

Start this one-step workflow.

1. Save the json in `signal-bug.json`:

```json
{
  "document": {
    "dsl": "1.0.0",
    "namespace": "default",
    "name": "signal-bug-repro",
    "version": "0.0.1"
  },
  "do": [
    {
      "waitForSignal": {
        "metadata": {
          "timeout": "30s"
        },
        "listen": {
          "to": {
            "one": {
              "with": {
                "id": "test-signal",
                "type": "signal"
              }
            }
          }
        }
      }
    }
  ]
}
```

2. Start the workflow worker.

```bash
zigflow -f signal-bug.json
```

3. Fire one workflow.

```bash
   temporal workflow start \
     --task-queue default \
     --type signal-bug-repro \
     --workflow-id signal-repro-001 \
     --input '{}'
```

4. Signal the WF with anything.

Go to UI to see the timer goes beyond the workflow.
<img width="1458" height="1161" alt="fix-off" src="https://github.com/user-attachments/assets/9b5c2454-e727-4e2a-b9a0-271175293937" />

---

With the proposed fix applied, it goes like expected:
<img width="1458" height="1195" alt="fix-on" src="https://github.com/user-attachments/assets/dba30cad-d884-4e94-ae0c-e30cc2b8f6e8" />

I ran the test suite after the fix. All passed.
