### PR TITLE
fix: clone the arguments without polluting the task

### DIFF
--- a/pkg/zigflow/tasks/task_builder_call_activity_test.go
+++ b/pkg/zigflow/tasks/task_builder_call_activity_test.go
@@ -55,9 +55,10 @@ func TestCallActivityTaskBuilderExecute(t *testing.T) {
 
 	workflowFunc := func(ctx workflow.Context) (string, error) {
 		state := utils.NewState().AddWorkflowInfo(ctx)
-		state.Input = map[string]any{"message": "ping"}
+		input := map[string]any{"message": "ping"}
+		state.Input = input
 		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: time.Minute})
-		result, err := fn(ctx, nil, state)
+		result, err := fn(ctx, input, state)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This cloned the value and then overwrote it, which was pretty pointless. This now just returns the parsed values from the function so it doesn't break things.

Thanks @stonezhong for reporting this

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #215

## How to test
<!-- Provide steps to test this PR -->
