### PR TITLE
chore: put go version back to v1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mrsimonemms/zigflow
 
-go 1.26.0
+go 1.25
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
It appears that v1.26 is not in Go actions yet - https://github.com/mrsimonemms/zigflow/actions/runs/22025616845/job/63641719394

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
