### PR TITLE
fix(tasks): correct field access in exc detail evaluation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@
 # See scripts/generate-authors.sh to make modifications.
 
 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Dimsi <dimosh3k@gmail.com>
 Hynek <dimosh3k@gmail.com>
 Maciek Bryński <maciek@brynski.pl>
 mrsimonemms <275848+mrsimonemms@users.noreply.github.com>

--- a/pkg/zigflow/tasks/task_builder_raise.go
+++ b/pkg/zigflow/tasks/task_builder_raise.go
@@ -92,7 +92,7 @@ func (t *RaiseTaskBuilder) Build() (TemporalWorkflowFunc, error) {
 		var detailResult any = ""
 
 		if definition := t.task.Raise.Error.Definition; definition != nil {
-			if detail := definition.Title; detail != nil {
+			if detail := definition.Detail; detail != nil {
 				detailResult, err = expr.TraverseAndEvaluateObj(
 					detail.AsObjectOrRuntimeExpr(),
 					state,


### PR DESCRIPTION
Propagate user error detail.

## Description
The `detail` block was incorrectly checking `definition.Title` instead of `definition.Detail`, causing the error detail message to use the wrong value.

## How to test
With this fix, imagine a decision like this:

```yml
# Yaml is not complete
  - decision:
      switch:
        - aPath:
            when: ${ $data.waitForSignal == "A" }
            then: activity-a
        - bPath:
            when: ${ $data.waitForSignal == "B" }
            then: activity-b
        - default:
            then: crash

# ...

  - crash:
      do:
        - fail:
            raise:
              error:
                type: "InvalidSignal"
                title: "Invalid Signal Error"
                status: 400
                detail: "Signal must be 'A' or 'B'"
```

Now, with the fix, `detail` field is shown in Tempotal UI.