### PR TITLE
Add remote codec server support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ tmp
 
 node_modules
 .venv
+__pycache__
+uv.lock
 
 .idea
 .DS_Store

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,7 @@ A collection of examples
 | [Money Transfer Demo](./money-transfer) | Temporal's world-famous Money Transfer Demo, in Zigflow form |
 | [Multiple Workflows](./multiple-workflows) | Configure multiple Temporal workflows from a single Zigflow definition |
 | [Python](./python) | The basic example, but in Python |
+| [Large Payload Example](./python-large-payload-codec) | Demonstrates using a custom PayloadCodec with Zigflow to handle large payloads via the claim-check pattern |
 | [Query Listeners](./query) | Listen for Temporal query events |
 | [Throw an error](./raise) | Throw an error from a Temporal workflow |
 | [Run Task](./run-task) | How to execute code in NodeJS, Python and Shell |

--- a/examples/python-large-payload-codec/README.md
+++ b/examples/python-large-payload-codec/README.md
@@ -1,0 +1,40 @@
+# Large Payload Codec
+
+Demonstrates using a custom PayloadCodec with Zigflow to handle large payloads
+via the claim-check pattern. Payloads exceeding 10KB are automatically
+offloaded to external storage.
+
+<!-- toc -->
+
+* [Getting started](#getting-started)
+
+<!-- Regenerate with "pre-commit run -a markdown-toc" -->
+
+<!-- tocstop -->
+
+## Getting started
+
+This example requires multiple terminals:
+
+```sh
+cd examples/python-large-payload-codec
+
+# Terminal 1: Start codec server
+uv run python codec_server.py
+
+# Terminal 2: Start Python activity worker
+uv run python worker.py
+
+# Terminal 3: Start Zigflow worker
+zigflow \
+  --file workflow.yaml \
+  --convert-data \
+  --codec-endpoint http://localhost:8081
+
+# Terminal 4: Run the starter
+uv run python starter.py
+```
+
+This will trigger the workflow, generate large payloads that exceed the 500KB
+threshold, and print the results to the console. You can configure the Temporal
+UI to use the codec server at `http://localhost:8081` to view decoded payloads.

--- a/examples/python-large-payload-codec/activities.py
+++ b/examples/python-large-payload-codec/activities.py
@@ -1,0 +1,121 @@
+# Copyright 2025 - 2026 Zigflow authors <https://github.com/mrsimonemms/zigflow/graphs/contributors>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Temporal activities for the large payload example.
+
+These activities generate and process large data, demonstrating how
+the custom codec transparently handles payloads exceeding 10KB.
+"""
+
+from __future__ import annotations
+
+from temporalio import activity
+
+
+@activity.defn
+async def generate_large_data(size_kb: int) -> bytes:
+    """
+    Generate large binary data of the specified size.
+
+    This activity returns data that will exceed the 10KB codec threshold,
+    triggering automatic offloading to external storage.
+
+    Args:
+        size_kb: Size of data to generate in kilobytes
+
+    Returns:
+        Binary data of the specified size
+    """
+    activity.logger.info(f"Generating {size_kb}KB of data...")
+
+    # Generate a repeated pattern of bytes
+    data = b"a" * (size_kb * 1024)
+
+    activity.logger.info(f"Generated {len(data)} bytes ({size_kb}KB)")
+    return data
+
+
+@activity.defn
+async def process_large_data(data: bytes) -> str:
+    """
+    Process large binary data received from the workflow.
+
+    The data is automatically decoded by the custom codec before
+    this activity receives it (if it exceeded 10KB).
+
+    Args:
+        data: Binary data to process
+
+    Returns:
+        String describing the processed data
+    """
+    size = len(data)
+    size_kb = size / 1024
+
+    activity.logger.info(f"Processing data of size: {size} bytes ({size_kb:.2f}KB)")
+
+    # Simulate some processing
+    # In a real scenario, this might be data transformation, validation, etc.
+    result = f"Processed {size} bytes ({size_kb:.2f}KB) of data"
+
+    activity.logger.info(f"Processing complete: {result}")
+    return result
+
+
+@activity.defn
+async def generate_large_string(size_kb: int) -> str:
+    """
+    Generate large string data of the specified size.
+
+    This demonstrates that the codec works with different data types,
+    not just binary data. The threshold for offload is 10KB.
+
+    Args:
+        size_kb: Size of string to generate in kilobytes
+
+    Returns:
+        String data of the specified size
+    """
+    activity.logger.info(f"Generating {size_kb}KB of string data...")
+
+    # Generate a repeated pattern of characters
+    data = "s" * (size_kb * 1024)
+
+    activity.logger.info(f"Generated {len(data)} characters ({size_kb}KB)")
+    return data
+
+
+@activity.defn
+async def process_large_string(data: str) -> str:
+    """
+    Process large string data received from the workflow (offloaded if >10KB).
+
+    Args:
+        data: String data to process
+
+    Returns:
+        String describing the processed data
+    """
+    size = len(data)
+    size_kb = size / 1024
+
+    activity.logger.info(
+        f"Processing string data of size: {size} characters ({size_kb:.2f}KB)"
+    )
+
+    result = f"Processed {size} characters ({size_kb:.2f}KB) of string data"
+
+    activity.logger.info(f"Processing complete: {result}")
+    return result

--- a/examples/python-large-payload-codec/codec.py
+++ b/examples/python-large-payload-codec/codec.py
@@ -1,0 +1,95 @@
+# Copyright 2025 - 2026 Zigflow authors <https://github.com/mrsimonemms/zigflow/graphs/contributors>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import uuid
+from pathlib import Path
+from typing import Iterable, List
+import tempfile
+from temporalio.api.common.v1 import Payload
+from temporalio.converter import PayloadCodec
+
+# Directory where large payloads will be stored.
+# In a real environment, this should be a shared volume, S3 bucket, etc.
+STORAGE_DIR = Path(tempfile.gettempdir()) / "temporal_large_payloads"
+# Threshold in bytes. 10KB for demo purposes.
+SIZE_THRESHOLD = 10 * 1024
+
+
+class LargePayloadCodec(PayloadCodec):
+    def __init__(self) -> None:
+        STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+
+    async def encode(self, payloads: Iterable[Payload]) -> List[Payload]:
+        encoded_payloads = []
+        for p in payloads:
+            # We handle any payload types.
+            # If the raw data size is larger than threshold, offload it.
+            if len(p.data) > SIZE_THRESHOLD:
+                # 1. Generate unique ID for offloaded file
+                file_id = str(uuid.uuid4())
+                file_path = STORAGE_DIR / file_id
+
+                # 2. Persist the ENTIRE payload (metadata + data) to disk
+                #    This preserves encoding metadata from previous converters (e.g. JSON/Protobuf)
+                with open(file_path, "wb") as f:
+                    f.write(p.SerializeToString())
+
+                # 3. Create a reference payload
+                #    We use a custom encoding type to identify it during decode
+                ref_obj = {"_large_payload_ref": file_id}
+                ref_data = json.dumps(ref_obj).encode("utf-8")
+
+                encoded_payloads.append(
+                    Payload(
+                        metadata={"encoding": b"binary/large-payload-ref"},
+                        data=ref_data,
+                    )
+                )
+            else:
+                encoded_payloads.append(p)
+
+        return encoded_payloads
+
+    async def decode(self, payloads: Iterable[Payload]) -> List[Payload]:
+        decoded_payloads = []
+        for p in payloads:
+            # Check if this is our reference type
+            if p.metadata.get("encoding") == b"binary/large-payload-ref":
+                try:
+                    ref = json.loads(p.data.decode("utf-8"))
+                    file_id = ref["_large_payload_ref"]
+                    file_path = STORAGE_DIR / file_id
+
+                    if not file_path.exists():
+                        # In production, you might want to handle this gracefully or retry
+                        raise RuntimeError(f"Large payload file not found: {file_path}")
+
+                    # 1. Read the bytes
+                    with open(file_path, "rb") as f:
+                        serialized_payload = f.read()
+
+                    # 2. Deserialize back into a Payload object
+                    original_payload = Payload()
+                    original_payload.ParseFromString(serialized_payload)
+
+                    decoded_payloads.append(original_payload)
+
+                except Exception as e:
+                    # Log error and potentially return original (ref) payload or raise
+                    print(f"Error decoding large payload: {e}")
+                    decoded_payloads.append(p)
+            else:
+                decoded_payloads.append(p)
+        return decoded_payloads

--- a/examples/python-large-payload-codec/codec_server.py
+++ b/examples/python-large-payload-codec/codec_server.py
@@ -1,0 +1,78 @@
+# Copyright 2025 - 2026 Zigflow authors <https://github.com/mrsimonemms/zigflow/graphs/contributors>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+from typing import Awaitable, Callable, Iterable, List
+
+from aiohttp import hdrs, web
+from google.protobuf import json_format
+from temporalio.api.common.v1 import Payload, Payloads
+
+from codec import LargePayloadCodec
+
+
+def build_codec_server() -> web.Application:
+    # Health check endpoint
+    async def health_check(req: web.Request) -> web.Response:
+        return web.json_response({"status": "healthy", "service": "codec-server"})
+
+    # Cors handler
+    async def cors_options(req: web.Request) -> web.Response:
+        resp = web.Response()
+        # Allow requests from the Temporal Web UI (default typically at 8233)
+        origin = req.headers.get(hdrs.ORIGIN)
+        if origin:
+            resp.headers[hdrs.ACCESS_CONTROL_ALLOW_ORIGIN] = origin
+            resp.headers[hdrs.ACCESS_CONTROL_ALLOW_METHODS] = "POST, OPTIONS"
+            resp.headers[hdrs.ACCESS_CONTROL_ALLOW_HEADERS] = "content-type,x-namespace"
+        return resp
+
+    # General purpose payloads-to-payloads
+    async def apply(
+        fn: Callable[[Iterable[Payload]], Awaitable[List[Payload]]], req: web.Request
+    ) -> web.Response:
+        # Read payloads as JSON
+        assert req.content_type == "application/json"
+        body = await req.read()
+        payloads = json_format.Parse(body, Payloads())
+
+        # Apply
+        new_payloads = Payloads(payloads=await fn(payloads.payloads))
+
+        # Apply CORS and return JSON
+        resp = await cors_options(req)
+        resp.content_type = "application/json"
+
+        # We must use proper proto-json printing
+        resp.text = json_format.MessageToJson(new_payloads)
+        return resp
+
+    # Build app
+    codec = LargePayloadCodec()
+    app = web.Application()
+    app.add_routes(
+        [
+            web.get("/health", health_check),
+            web.post("/encode", partial(apply, codec.encode)),
+            web.post("/decode", partial(apply, codec.decode)),
+            web.options("/decode", cors_options),
+            web.options("/encode", cors_options),
+        ]
+    )
+    return app
+
+
+if __name__ == "__main__":
+    print("Codec server starting on http://127.0.0.1:8081")
+    web.run_app(build_codec_server(), host="127.0.0.1", port=8081)

--- a/examples/python-large-payload-codec/pyproject.toml
+++ b/examples/python-large-payload-codec/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "zigflow-large-payload-codec-example"
+version = "0.1.0"
+description = "Example of using custom PayloadCodec with Zigflow"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "temporalio>=1.8.0",
+    "aiohttp>=3.10.0",
+    "protobuf>=5.29.0",
+]
+
+[tool.uv]
+package = false

--- a/examples/python-large-payload-codec/starter.py
+++ b/examples/python-large-payload-codec/starter.py
@@ -1,0 +1,75 @@
+# Copyright 2025 - 2026 Zigflow authors <https://github.com/mrsimonemms/zigflow/graphs/contributors>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Trigger the large payload example workflow defined in workflow.yaml."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import os
+import sys
+import uuid
+from typing import Any, Dict
+
+from temporalio.client import Client
+import temporalio.converter
+
+from codec import LargePayloadCodec
+
+
+async def main() -> None:
+    address = os.getenv("TEMPORAL_ADDRESS", "localhost:7233")
+    namespace = os.getenv("TEMPORAL_NAMESPACE", "default")
+    api_key = os.getenv("TEMPORAL_API_KEY")
+    tls_enabled = os.getenv("TEMPORAL_TLS", "false").lower() == "true"
+
+    connect_kwargs: Dict[str, Any] = {"namespace": namespace}
+    if tls_enabled:
+        connect_kwargs["tls"] = True
+    if api_key:
+        connect_kwargs["api_key"] = api_key
+
+    data_converter = dataclasses.replace(
+        temporalio.converter.default(), payload_codec=LargePayloadCodec()
+    )
+    connect_kwargs["data_converter"] = data_converter
+
+    client = await Client.connect(address, **connect_kwargs)
+
+    handle = await client.start_workflow(
+        "large-payload-example",
+        {"size_kb": 12},
+        id=f"large-payload-{uuid.uuid4().hex}",
+        task_queue="zigflow",
+    )
+
+    print(f"Started workflow: {handle.id}")
+    result = await handle.result()
+    print(result)
+
+
+def _run() -> None:
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("Cancelled", file=sys.stderr)
+        sys.exit(130)
+    except Exception as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    _run()

--- a/examples/python-large-payload-codec/worker.py
+++ b/examples/python-large-payload-codec/worker.py
@@ -1,0 +1,87 @@
+# Copyright 2025 - 2026 Zigflow authors <https://github.com/mrsimonemms/zigflow/graphs/contributors>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python Temporal worker for large payload activities."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+import os
+import sys
+from typing import Any, Dict
+
+from temporalio.client import Client
+from temporalio.worker import Worker
+import temporalio.converter
+
+from activities import (
+    generate_large_data,
+    process_large_data,
+    generate_large_string,
+    process_large_string,
+)
+from codec import LargePayloadCodec
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+
+    address = os.getenv("TEMPORAL_ADDRESS", "localhost:7233")
+    namespace = os.getenv("TEMPORAL_NAMESPACE", "default")
+    api_key = os.getenv("TEMPORAL_API_KEY")
+    tls_enabled = os.getenv("TEMPORAL_TLS", "false").lower() == "true"
+
+    connect_kwargs: Dict[str, Any] = {"namespace": namespace}
+    if tls_enabled:
+        connect_kwargs["tls"] = True
+    if api_key:
+        connect_kwargs["api_key"] = api_key
+
+    data_converter = dataclasses.replace(
+        temporalio.converter.default(), payload_codec=LargePayloadCodec()
+    )
+    connect_kwargs["data_converter"] = data_converter
+
+    client = await Client.connect(address, **connect_kwargs)
+
+    worker = Worker(
+        client,
+        task_queue="python-activities",
+        activities=[
+            generate_large_data,
+            process_large_data,
+            generate_large_string,
+            process_large_string,
+        ],
+    )
+
+    print("Python activity worker started")
+    await worker.run()
+
+
+def _run() -> None:
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\nWorker stopped", file=sys.stderr)
+        sys.exit(0)
+    except Exception as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    _run()

--- a/examples/python-large-payload-codec/workflow.yaml
+++ b/examples/python-large-payload-codec/workflow.yaml
@@ -1,0 +1,91 @@
+document:
+  dsl: 1.0.0
+  namespace: zigflow
+  name: large-payload-example
+  version: 0.0.1
+  title: Large Payload Example
+  summary: Demonstrates using a custom PayloadCodec with Zigflow to handle large payloads via the claim-check pattern
+  metadata:
+    display: false
+
+# Input: size_kb - how many KB of data to generate
+input:
+  schema:
+    format: json
+    document:
+      type: object
+      required:
+        - size_kb
+      properties:
+        size_kb:
+          type: number
+          description: Size of data to generate in kilobytes (KB)
+
+timeout:
+  after:
+    minutes: 5
+
+do:
+  # Step 1: Capture input
+  - captureInput:
+      set:
+        requestedSize: ${ $input.size_kb }
+        workflowId: ${ uuid }
+
+  # Step 2: Generate large data via Python activity
+  # This will create data larger than 500KB threshold, triggering the codec
+  - generateData:
+      call: activity
+      export:
+        as: '${ $context + { generateData: . } }'
+      with:
+        name: generate_large_data
+        arguments:
+          - ${ $data.requestedSize }
+        taskQueue: python-activities
+
+  # Step 3: Process the large data via Python activity
+  # The large payload will be transparently decoded and re-encoded by the codec
+  - processData:
+      call: activity
+      export:
+        as: '${ $context + { processData: . } }'
+      with:
+        name: process_large_data
+        arguments:
+          - ${ $data.generateData }
+        taskQueue: python-activities
+
+  # Step 4: Generate large string data
+  - generateString:
+      call: activity
+      export:
+        as: '${ $context + { generateString: . } }'
+      with:
+        name: generate_large_string
+        arguments:
+          - ${ $data.requestedSize }
+        taskQueue: python-activities
+
+  # Step 5: Process the large string data
+  - processString:
+      call: activity
+      export:
+        as: '${ $context + { processString: . } }'
+      with:
+        name: process_large_string
+        arguments:
+          - ${ $data.generateString }
+        taskQueue: python-activities
+
+  # Step 6: Return results
+  - returnResults:
+      export:
+        as:
+          data: ${ . }
+      set:
+        workflowId: ${ $data.workflowId }
+        requestedSize: ${ $data.requestedSize }
+        processDataResult: ${ $data.processData }
+        processStringResult: ${ $data.processString }
+        success: true

--- a/pkg/codec/remote.go
+++ b/pkg/codec/remote.go
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/mrsimonemms/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package codec
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// RemoteCodecDataConverter is a DataConverter that delegates encoding and decoding
+// to a remote codec server via HTTP. This allows using custom codecs (e.g., compression,
+// encryption) implemented in any language without embedding them in the Zigflow binary.
+//
+// The remote codec server must implement two endpoints:
+//   - POST /encode - accepts Payloads, returns encoded Payloads
+//   - POST /decode - accepts Payloads, returns decoded Payloads
+//
+// Both endpoints expect and return Temporal Payloads in JSON format.
+type RemoteCodecDataConverter struct {
+	parent   converter.DataConverter
+	endpoint string
+	client   *http.Client
+}
+
+// NewRemoteCodecDataConverter creates a new RemoteCodecDataConverter that sends
+// encoding/decoding requests to the specified HTTP endpoint.
+//
+// The parent DataConverter is used for the initial serialisation before encoding
+// and final deserialization after decoding. If nil, the default Temporal converter is used.
+func NewRemoteCodecDataConverter(endpoint string, parent converter.DataConverter) *RemoteCodecDataConverter {
+	if parent == nil {
+		parent = converter.GetDefaultDataConverter()
+	}
+
+	return &RemoteCodecDataConverter{
+		parent:   parent,
+		endpoint: endpoint,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// ToPayloads converts a list of values to payloads and applies remote encoding.
+func (r *RemoteCodecDataConverter) ToPayloads(values ...interface{}) (*commonpb.Payloads, error) {
+	// First, convert values to payloads using the parent converter
+	payloads, err := r.parent.ToPayloads(values...)
+	if err != nil {
+		return nil, fmt.Errorf("parent converter ToPayloads failed: %w", err)
+	}
+
+	// Then, apply remote encoding
+	encoded, err := r.encode(payloads)
+	if err != nil {
+		return nil, fmt.Errorf("remote encoding failed: %w", err)
+	}
+
+	return encoded, nil
+}
+
+// FromPayloads applies remote decoding and converts payloads back to values.
+func (r *RemoteCodecDataConverter) FromPayloads(payloads *commonpb.Payloads, valuePtrs ...interface{}) error {
+	// First, apply remote decoding
+	decoded, err := r.decode(payloads)
+	if err != nil {
+		return fmt.Errorf("remote decoding failed: %w", err)
+	}
+
+	// Then, convert payloads back to values using the parent converter
+	if err := r.parent.FromPayloads(decoded, valuePtrs...); err != nil {
+		return fmt.Errorf("parent converter FromPayloads failed: %w", err)
+	}
+
+	return nil
+}
+
+// ToString converts a single payload to a string representation.
+// This is primarily used for debugging and logging.
+func (r *RemoteCodecDataConverter) ToString(payload *commonpb.Payload) string {
+	return r.parent.ToString(payload)
+}
+
+// ToStrings converts payloads to string representations.
+// This is primarily used for debugging and logging.
+func (r *RemoteCodecDataConverter) ToStrings(payloads *commonpb.Payloads) []string {
+	return r.parent.ToStrings(payloads)
+}
+
+// encode sends payloads to the remote codec server for encoding.
+func (r *RemoteCodecDataConverter) encode(payloads *commonpb.Payloads) (*commonpb.Payloads, error) {
+	return r.callCodecServer("/encode", payloads)
+}
+
+// decode sends payloads to the remote codec server for decoding.
+func (r *RemoteCodecDataConverter) decode(payloads *commonpb.Payloads) (*commonpb.Payloads, error) {
+	return r.callCodecServer("/decode", payloads)
+}
+
+// callCodecServer makes an HTTP POST request to the remote codec server.
+//
+// Note: This uses context.Background() because the Temporal DataConverter interface
+// does not pass context through ToPayloads/FromPayloads. The HTTP client timeout
+// (30 seconds) provides protection against hung requests.
+func (r *RemoteCodecDataConverter) callCodecServer(path string, payloads *commonpb.Payloads) (*commonpb.Payloads, error) {
+	if payloads == nil || len(payloads.Payloads) == 0 {
+		return payloads, nil
+	}
+
+	// Marshal payloads to JSON using protojson to handle protobuf properly
+	jsonData, err := protojson.Marshal(payloads)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal payloads to JSON: %w", err)
+	}
+
+	// Create HTTP request
+	url := r.endpoint + path
+	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request to %s: %w", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	log.Trace().
+		Str("url", url).
+		Str("method", "POST").
+		Msg("Calling remote codec server")
+
+	// Make the request
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call codec server at %s: %w", url, err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Warn().Err(err).Msg("Failed to close response body")
+		}
+	}()
+
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("codec server returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Read response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read codec server response: %w", err)
+	}
+
+	// Unmarshal response
+	var result commonpb.Payloads
+	if err := protojson.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal codec server response: %w", err)
+	}
+
+	log.Trace().
+		Int("inputPayloads", len(payloads.Payloads)).
+		Int("outputPayloads", len(result.Payloads)).
+		Msg("Remote codec server call successful")
+
+	return &result, nil
+}
+
+// ToPayload converts a single value to a payload.
+// This implements the PayloadConverter interface.
+func (r *RemoteCodecDataConverter) ToPayload(value interface{}) (*commonpb.Payload, error) {
+	payloads, err := r.ToPayloads(value)
+	if err != nil {
+		return nil, err
+	}
+	if len(payloads.Payloads) == 0 {
+		return nil, fmt.Errorf("no payload produced")
+	}
+	return payloads.Payloads[0], nil
+}
+
+// FromPayload converts a payload back to a value.
+// This implements the PayloadConverter interface.
+func (r *RemoteCodecDataConverter) FromPayload(payload *commonpb.Payload, valuePtr interface{}) error {
+	payloads := &commonpb.Payloads{Payloads: []*commonpb.Payload{payload}}
+	return r.FromPayloads(payloads, valuePtr)
+}

--- a/pkg/codec/remote_test.go
+++ b/pkg/codec/remote_test.go
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/mrsimonemms/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package codec
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func TestNewRemoteCodecDataConverter(t *testing.T) {
+	t.Run("uses default parent when nil", func(t *testing.T) {
+		r := NewRemoteCodecDataConverter("http://localhost:8081", nil)
+		assert.NotNil(t, r.parent)
+		assert.Equal(t, "http://localhost:8081", r.endpoint)
+		assert.NotNil(t, r.client)
+	})
+
+	t.Run("uses provided parent", func(t *testing.T) {
+		customParent := converter.GetDefaultDataConverter()
+		r := NewRemoteCodecDataConverter("http://localhost:8082", customParent)
+		assert.Equal(t, customParent, r.parent)
+	})
+}
+
+func TestRemoteCodecDataConverter_EmptyPayloads(t *testing.T) {
+	r := NewRemoteCodecDataConverter("http://localhost:8081", nil)
+
+	t.Run("encode nil payloads", func(t *testing.T) {
+		result, err := r.encode(nil)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("encode empty payloads", func(t *testing.T) {
+		result, err := r.encode(&commonpb.Payloads{})
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+	})
+
+	t.Run("decode nil payloads", func(t *testing.T) {
+		result, err := r.decode(nil)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestRemoteCodecDataConverter_ServerCommunication(t *testing.T) {
+	t.Run("successful encode/decode roundtrip", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+
+			var payloads commonpb.Payloads
+			err = protojson.Unmarshal(body, &payloads)
+			assert.NoError(t, err)
+
+			w.Header().Set("Content-Type", "application/json")
+			resp, _ := protojson.Marshal(&payloads)
+			_, _ = w.Write(resp)
+		}))
+		defer server.Close()
+
+		r := NewRemoteCodecDataConverter(server.URL, nil)
+
+		payloads, err := r.ToPayloads("test-value")
+		assert.NoError(t, err)
+		assert.NotNil(t, payloads)
+		assert.NotEmpty(t, payloads.Payloads)
+
+		var result string
+		err = r.FromPayloads(payloads, &result)
+		assert.NoError(t, err)
+		assert.Equal(t, "test-value", result)
+	})
+
+	t.Run("server error response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("internal error"))
+		}))
+		defer server.Close()
+
+		r := NewRemoteCodecDataConverter(server.URL, nil)
+
+		_, err := r.ToPayloads("test")
+		assert.Error(t, err)
+	})
+
+	t.Run("server unavailable", func(t *testing.T) {
+		r := NewRemoteCodecDataConverter("http://localhost:59999", nil)
+
+		_, err := r.ToPayloads("test")
+		assert.Error(t, err)
+	})
+}
+
+func TestRemoteCodecDataConverter_ToPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+
+		var payloads commonpb.Payloads
+		_ = protojson.Unmarshal(body, &payloads)
+
+		w.Header().Set("Content-Type", "application/json")
+		resp, _ := protojson.Marshal(&payloads)
+		_, _ = w.Write(resp)
+	}))
+	defer server.Close()
+
+	r := NewRemoteCodecDataConverter(server.URL, nil)
+
+	payload, err := r.ToPayload("single-value")
+	assert.NoError(t, err)
+	assert.NotNil(t, payload)
+
+	var result string
+	err = r.FromPayload(payload, &result)
+	assert.NoError(t, err)
+	assert.Equal(t, "single-value", result)
+}
+
+func TestRemoteCodecDataConverter_ToString(t *testing.T) {
+	r := NewRemoteCodecDataConverter("http://localhost:8081", nil)
+
+	payload := &commonpb.Payload{
+		Metadata: map[string][]byte{"encoding": []byte("json/plain")},
+		Data:     []byte(`"test"`),
+	}
+
+	str := r.ToString(payload)
+	assert.NotEmpty(t, str)
+
+	payloads := &commonpb.Payloads{Payloads: []*commonpb.Payload{payload}}
+	strs := r.ToStrings(payloads)
+	assert.Len(t, strs, 1)
+}


### PR DESCRIPTION
## Description
Adds `--codec-endpoint` flag to delegate payload encoding/decoding to an external HTTP codec server. This enables custom codecs (compression, encryption, claim-check pattern) implemented in any language.

**CLI changes**

- New `--codec-endpoint` flag: specify remote codec server URL (requires `--convert-data`)
- `--convert-data` now supports both local AES (`--converter-key-path`, already existed) and remote codec modes (`--codec-endpoint`)
- Mutually exclusive: cannot use `--converter-key-path` with `--codec-endpoint`

**New components**

`remote.go`: `RemoteCodecDataConverter` implementing Temporal's `DataConverter` interface Unit tests for the remote codec

**Limitations, Considerations**

- HTTP requests use `context.Background()` with a fixed 30s timeout (Temporal's `DataConverter` interface doesn't propagate context through `ToPayloads`/`FromPayloads`)
- **Known behavior**: HTTP calls to the codec server (`remote.go`) are not retried at the converter level. Transient failures will cause a workflow task failure, which Temporal will retry according to task retry policy. This is intentional to avoid masking codec server issues.

## Related Issue(s)
Fixes #249

## How to test
Excerpt from `./examples/python-large-payload-codec/README.md`:

```sh
cd examples/python-large-payload-codec

# Terminal 1: Start codec server
uv run python codec_server.py

# Terminal 2: Start Python activity worker
uv run python worker.py

# Terminal 3: Start Zigflow worker
zigflow \
  --file workflow.yaml \
  --convert-data \
  --codec-endpoint http://localhost:8081

# Terminal 4: Run the starter
uv run python starter.py
```

This will trigger the workflow, generate _large_ payloads that exceed the 10KB threshold, and print the results to the console. You can configure the Temporal UI to use the codec server at `http://localhost:8081` to view decoded payloads.

---

The PR looks large, but its mostly `./examples/python-large-payload-codec`.