### PR TITLE
fix: reduce default start to close timeout to 15s

### DIFF
--- a/docs/docs/concepts/error-handling-and-retries.md
+++ b/docs/docs/concepts/error-handling-and-retries.md
@@ -162,7 +162,7 @@ A `raise` inside the `try` block is caught by the `catch` block. Use this
 intentionally only if you want to normalise errors to a consistent format.
 
 **Not setting `startToCloseTimeout` for long-running activities.**
-The default start-to-close timeout is 5 minutes. Long-running activities
+The default start-to-close timeout is 15 seconds. Long-running activities
 (such as container executions or waiting on external systems) should increase
 this via `metadata.activityOptions.startToCloseTimeout`.
 

--- a/docs/docs/dsl/intro.md
+++ b/docs/docs/dsl/intro.md
@@ -38,7 +38,7 @@ optimise efficiency within an organisation.
 | document | [`document`](#document) | `yes` | Documents the defined workflow. |
 | do | [`map[string, task]`](/docs/dsl/tasks/intro) | `yes` | The [task(s)](/docs/dsl/tasks/intro) that must be performed by the [workflow](#workflow). |
 | input | [`input`](#input) | `no` | Configures the workflow's input. |
-| timeout | [`timeout`](#timeout) | `no` | The configuration of the workflow's activity [Start-To-Close timeout](https://docs.temporal.io/encyclopedia/detecting-activity-failures#start-to-close-timeout). Defaults to 5 minutes |
+| timeout | [`timeout`](#timeout) | `no` | The configuration of the workflow's activity [Start-To-Close timeout](https://docs.temporal.io/encyclopedia/detecting-activity-failures#start-to-close-timeout). Defaults to 15 seconds |
 | schedule | [`schedule`](#schedule) | `no` | Configures the workflow's schedule, if any. |
 
 ## Document

--- a/docs/docs/dsl/metadata/activity-options.md
+++ b/docs/docs/dsl/metadata/activity-options.md
@@ -32,7 +32,7 @@ cases. In most scenarios, you probably won't need to configure this.
 | heartbeatTimeout | [`duration`](/docs/dsl/intro#duration) | `no` | - | Heartbeat interval. A [`heartbeat`](/docs/dsl/metadata/heartbeat) must be set and be called before the interval passes. |
 | scheduleToCloseTimeout | [`duration`](/docs/dsl/intro#duration) | `no` | - | Total time that a workflow is willing to wait for an Activity to complete |
 | scheduleToStartTimeout | [`duration`](/docs/dsl/intro#duration) | `no` | - | Time that the Activity Task can stay in the Task Queue before it is picked up by a Worker. Do not specify this timeout unless using host specific Task Queues for Activity Tasks are being used for routing |
-| startToCloseTimeout | [`duration`](/docs/dsl/intro#duration) | `no` | `{"minutes":5}` | Maximum time of a single Activity execution attempt |
+| startToCloseTimeout | [`duration`](/docs/dsl/intro#duration) | `no` | `{"seconds":15}` | Maximum time of a single Activity execution attempt |
 | retryPolicy | [`RetryPolicy`](#types-retry-policy) | `no` | - | Specifies how to retry an Activity if an error occurs |
 | disableEagerExecution | `boolean` | `no` | `false` | If `true`, eager execution will not be requested, regardless of worker settings. If `false`, eager execution may still be disabled at the worker level or may not be requested due to lack of available slots. |
 | summary | `string` | `no` | The task's name | Add a summary to the Temporal workflow UI |

--- a/pkg/zigflow/metadata/activity_options_test.go
+++ b/pkg/zigflow/metadata/activity_options_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/zigflow/zigflow/pkg/utils"
 	"github.com/zigflow/zigflow/pkg/zigflow/metadata"
 	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
 )
 
 func TestConvertRetryPolicy(t *testing.T) {
@@ -63,4 +65,109 @@ func TestConvertRetryPolicy(t *testing.T) {
 			assert.Equal(t, test.Expected, test.RetryPolicy.ToTemporal(test.Starting))
 		})
 	}
+}
+
+// runSetActivityOptions executes SetActivityOptions inside a test workflow environment
+// and returns the resulting ActivityOptions. It captures the options via a channel
+// because workflow functions run in a coroutine managed by the test suite.
+func runSetActivityOptions(t *testing.T, wf *model.Workflow, task *model.TaskBase) (workflow.ActivityOptions, error) {
+	t.Helper()
+
+	var s testsuite.WorkflowTestSuite
+	env := s.NewTestWorkflowEnvironment()
+
+	type result struct {
+		opts workflow.ActivityOptions
+		err  error
+	}
+	ch := make(chan result, 1)
+
+	env.ExecuteWorkflow(func(ctx workflow.Context) error {
+		newCtx, err := metadata.SetActivityOptions(ctx, wf, task, "testTask")
+		if err != nil {
+			ch <- result{err: err}
+			return err
+		}
+		ch <- result{opts: workflow.GetActivityOptions(newCtx)}
+		return nil
+	})
+
+	assert.NoError(t, env.GetWorkflowError())
+	r := <-ch
+	return r.opts, r.err
+}
+
+func TestSetActivityOptionsDefaultTimeout(t *testing.T) {
+	wf := &model.Workflow{
+		Document: model.Document{},
+	}
+	task := &model.TaskBase{}
+
+	opts, err := runSetActivityOptions(t, wf, task)
+	assert.NoError(t, err)
+	assert.Equal(t, 15*time.Second, opts.StartToCloseTimeout)
+}
+
+func TestSetActivityOptionsWorkflowTimeoutOverride(t *testing.T) {
+	after := &model.Duration{Value: model.DurationInline{Minutes: 2}}
+	wf := &model.Workflow{
+		Document: model.Document{},
+		Timeout: &model.TimeoutOrReference{
+			Timeout: &model.Timeout{
+				After: after,
+			},
+		},
+	}
+	task := &model.TaskBase{}
+
+	opts, err := runSetActivityOptions(t, wf, task)
+	assert.NoError(t, err)
+	assert.Equal(t, 2*time.Minute, opts.StartToCloseTimeout)
+}
+
+func TestSetActivityOptionsGlobalMetadataOverride(t *testing.T) {
+	wf := &model.Workflow{
+		Document: model.Document{
+			Metadata: map[string]any{
+				metadata.MetadataActivityOptions: map[string]any{
+					"startToCloseTimeout": map[string]any{"minutes": 3},
+				},
+			},
+		},
+	}
+	task := &model.TaskBase{}
+
+	opts, err := runSetActivityOptions(t, wf, task)
+	assert.NoError(t, err)
+	assert.Equal(t, 3*time.Minute, opts.StartToCloseTimeout)
+}
+
+func TestSetActivityOptionsTaskMetadataOverridePrecedence(t *testing.T) {
+	// Workflow timeout and global metadata both set, task-level must win.
+	after := &model.Duration{Value: model.DurationInline{Minutes: 2}}
+	wf := &model.Workflow{
+		Document: model.Document{
+			Metadata: map[string]any{
+				metadata.MetadataActivityOptions: map[string]any{
+					"startToCloseTimeout": map[string]any{"minutes": 3},
+				},
+			},
+		},
+		Timeout: &model.TimeoutOrReference{
+			Timeout: &model.Timeout{
+				After: after,
+			},
+		},
+	}
+	task := &model.TaskBase{
+		Metadata: map[string]any{
+			metadata.MetadataActivityOptions: map[string]any{
+				"startToCloseTimeout": map[string]any{"seconds": 30},
+			},
+		},
+	}
+
+	opts, err := runSetActivityOptions(t, wf, task)
+	assert.NoError(t, err)
+	assert.Equal(t, 30*time.Second, opts.StartToCloseTimeout)
 }

--- a/pkg/zigflow/metadata/constants.go
+++ b/pkg/zigflow/metadata/constants.go
@@ -36,7 +36,7 @@ const (
 
 const MaxHistoryLengthAttribute string = "canMaxHistoryLength"
 
-const defaultWorkflowTimeout = time.Minute * 5
+const defaultWorkflowTimeout = time.Second * 15
 
 var defaultRetryPolicy = &temporal.RetryPolicy{
 	InitialInterval:    time.Second,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Sets default start to close timeout to 15 seconds from 5 minutes

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #319

## How to test
<!-- Provide steps to test this PR -->
