### PR TITLE
fix(run): evaluate runtime expressions in map[string]string env values #fixes 341

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Hynek <dimosh3k@gmail.com>
 Maciek Bryński <maciek@brynski.pl>
 mrsimonemms <275848+mrsimonemms@users.noreply.github.com>
 Simon Emms <simon@simonemms.com>
+Sumit <sumit.seeftech@gmail.com>

--- a/examples/run-task/workflow.yaml
+++ b/examples/run-task/workflow.yaml
@@ -21,6 +21,7 @@ do:
             - env
           environment:
             hello: world
+            apikey: '${ $env.API_KEY }'
   - nodejs:
       export:
         as: '${ $context + { nodejs: . } }'

--- a/pkg/utils/runtime_expressions.go
+++ b/pkg/utils/runtime_expressions.go
@@ -166,6 +166,16 @@ func traverseAndEvaluate(node, ctx any, state *State, evaluationWrapper Expressi
 			v[key] = evaluatedValue
 		}
 		return v, nil
+	case map[string]string:
+		// Traverse map values for string-only maps (for example, run task environment vars).
+		for key, value := range v {
+			evaluatedValue, err := traverseAndEvaluate(value, ctx, state, evaluationWrapper)
+			if err != nil {
+				return nil, err
+			}
+			v[key] = fmt.Sprintf("%v", evaluatedValue)
+		}
+		return v, nil
 	case []any:
 		// Traverse an array
 		return traverseSlice(v, ctx, state, evaluationWrapper)

--- a/pkg/utils/runtime_expressions_test.go
+++ b/pkg/utils/runtime_expressions_test.go
@@ -467,6 +467,25 @@ func TestTraverseAndEvaluateObj(t *testing.T) {
 	}
 }
 
+func TestTraverseAndEvaluateObjMapStringString(t *testing.T) {
+	state := NewState()
+	state.Env["OPENAI_API_KEY"] = "secret-key"
+
+	obj := model.NewObjectOrRuntimeExpr(map[string]any{
+		"env": map[string]string{
+			"OPENAI_API_KEY": "${ $env.OPENAI_API_KEY }",
+		},
+	})
+
+	result, err := TraverseAndEvaluateObj(obj, nil, state)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"env": map[string]string{
+			"OPENAI_API_KEY": "secret-key",
+		},
+	}, result)
+}
+
 func TestTraverseAndEvaluateObjWithWrapper(t *testing.T) {
 	t.Run("wrapper is called for expression values in a map", func(t *testing.T) {
 		callCount := 0

--- a/pkg/zigflow/activities/run.go
+++ b/pkg/zigflow/activities/run.go
@@ -130,6 +130,13 @@ func (r *Run) runDockerCommand(ctx context.Context, task *model.RunTask, state *
 		return nil, temporal.NewNonRetryableApplicationError("Docker not installed", "container", err)
 	}
 
+	state = state.Clone().AddActivityInfo(ctx)
+
+	containerData, err := interpolateContainerConfig(task, state)
+	if err != nil {
+		return nil, err
+	}
+
 	cmd := []string{
 		"docker",
 		"run",
@@ -140,37 +147,151 @@ func (r *Run) runDockerCommand(ctx context.Context, task *model.RunTask, state *
 		fmt.Sprintf("--name=%s", task.Run.Container.Name),
 	}
 
-	if c := task.Run.Container.Command; c != "" {
-		cmd = append(cmd, fmt.Sprintf("--entrypoint=%s", c))
+	entrypoint, hasEntrypoint, err := dockerEntrypointFromInterpolated(containerData["command"])
+	if err != nil {
+		return nil, err
+	}
+	if hasEntrypoint {
+		cmd = append(cmd, fmt.Sprintf("--entrypoint=%s", entrypoint))
 	}
 
 	if task.Run.Container.Lifetime == nil || task.Run.Container.Lifetime.Cleanup == "always" {
 		cmd = append(cmd, "--rm")
 	}
 
-	if envs := task.Run.Container.Environment; envs != nil {
+	cmd = appendDockerEnvFlags(cmd, containerData["environment"])
+	cmd, err = appendDockerVolumeFlags(cmd, containerData["volumes"])
+	if err != nil {
+		return nil, err
+	}
+
+	image, err := dockerImageFromInterpolated(containerData["image"])
+	if err != nil {
+		return nil, err
+	}
+	cmd = append(cmd, image)
+
+	args, err := dockerArgsFromInterpolated(containerData["arguments"])
+	if err != nil {
+		return nil, err
+	}
+	cmd = append(cmd, args...)
+
+	return r.runExecCommand(ctx, []string{cmd[0]}, &model.RunArguments{Value: cmd[1:]}, nil, state, "", task.GetBase())
+}
+
+func interpolateContainerConfig(task *model.RunTask, state *utils.State) (map[string]any, error) {
+	interpolatedContainer, err := utils.TraverseAndEvaluateObj(model.NewObjectOrRuntimeExpr(map[string]any{
+		"image":       task.Run.Container.Image,
+		"command":     task.Run.Container.Command,
+		"environment": swUtil.DeepCloneValue(task.Run.Container.Environment),
+		"volumes":     swUtil.DeepCloneValue(task.Run.Container.Volumes),
+		"arguments":   swUtil.DeepCloneValue(task.Run.Container.Arguments),
+	}), nil, state)
+	if err != nil {
+		return nil, fmt.Errorf("error traversing container parameters: %w", err)
+	}
+	return interpolatedContainer.(map[string]any), nil
+}
+
+func appendDockerEnvFlags(cmd []string, envsRaw any) []string {
+	switch envs := envsRaw.(type) {
+	case nil:
+		return cmd
+	case map[string]string:
 		for k, v := range envs {
 			cmd = append(cmd, fmt.Sprintf("--env=%s=%s", k, v))
 		}
-	}
-
-	if vols := task.Run.Container.Volumes; vols != nil {
-		for k, remote := range vols {
-			local, err := filepath.Abs(k)
-			if err != nil {
-				return nil, fmt.Errorf("error getting volume absolute path: %w", err)
-			}
-
-			cmd = append(cmd, fmt.Sprintf("--volume=%s:%s", local, remote))
+	case map[string]any:
+		for k, v := range envs {
+			cmd = append(cmd, fmt.Sprintf("--env=%s=%s", k, fmt.Sprint(v)))
 		}
 	}
-	// Add in the image
-	cmd = append(cmd, task.Run.Container.Image)
+	return cmd
+}
 
-	// Add in arguments
-	cmd = append(cmd, task.Run.Container.Arguments...)
+func appendDockerVolumeFlags(cmd []string, volsRaw any) ([]string, error) {
+	var vols map[string]string
+	switch data := volsRaw.(type) {
+	case nil:
+		return cmd, nil
+	case map[string]string:
+		vols = data
+	case map[string]any:
+		vols = map[string]string{}
+		for local, remoteRaw := range data {
+			if remoteRaw == nil {
+				return nil, fmt.Errorf("invalid container volume for %q: destination cannot be null", local)
+			}
+			remote, ok := remoteRaw.(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid container volume for %q: expected string destination, got %T", local, remoteRaw)
+			}
+			vols[local] = remote
+		}
+	default:
+		return nil, fmt.Errorf("invalid container volumes: expected map, got %T", volsRaw)
+	}
 
-	return r.runExecCommand(ctx, []string{cmd[0]}, &model.RunArguments{Value: cmd[1:]}, nil, state, "", task.GetBase())
+	for k, remote := range vols {
+		local, err := filepath.Abs(k)
+		if err != nil {
+			return nil, fmt.Errorf("error getting volume absolute path: %w", err)
+		}
+
+		cmd = append(cmd, fmt.Sprintf("--volume=%s:%s", local, remote))
+	}
+	return cmd, nil
+}
+
+func dockerEntrypointFromInterpolated(commandRaw any) (entrypoint string, hasEntrypoint bool, err error) {
+	if commandRaw == nil {
+		return "", false, nil
+	}
+	command, ok := commandRaw.(string)
+	if !ok {
+		return "", false, fmt.Errorf("invalid container command: expected string, got %T", commandRaw)
+	}
+	if command == "" {
+		return "", false, nil
+	}
+	return command, true, nil
+}
+
+func dockerImageFromInterpolated(imageRaw any) (string, error) {
+	if imageRaw == nil {
+		return "", fmt.Errorf("invalid container image: value is required and cannot be null")
+	}
+	image, ok := imageRaw.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid container image: expected string, got %T", imageRaw)
+	}
+	if strings.TrimSpace(image) == "" {
+		return "", fmt.Errorf("invalid container image: value is required and cannot be empty")
+	}
+	return image, nil
+}
+
+func dockerArgsFromInterpolated(argsRaw any) ([]string, error) {
+	if argsRaw == nil {
+		return nil, nil
+	}
+
+	switch args := argsRaw.(type) {
+	case []string:
+		return args, nil
+	case []any:
+		containerArgs := make([]string, 0, len(args))
+		for i, arg := range args {
+			if arg == nil {
+				return nil, fmt.Errorf("invalid container argument at index %d: value cannot be null", i)
+			}
+			containerArgs = append(containerArgs, fmt.Sprint(arg))
+		}
+		return containerArgs, nil
+	default:
+		return nil, fmt.Errorf("invalid container arguments: expected array, got %T", argsRaw)
+	}
 }
 
 // runExecCommand a general purpose function to build and execute a command in an activity

--- a/pkg/zigflow/activities/run_test.go
+++ b/pkg/zigflow/activities/run_test.go
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2025 - 2026 Zigflow authors <https://github.com/zigflow/zigflow/graphs/contributors>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package activities
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zigflow/zigflow/pkg/utils"
+	"go.temporal.io/sdk/testsuite"
+)
+
+func TestCallShellActivityInterpolatesEnvironmentExpressions(t *testing.T) {
+	var s testsuite.WorkflowTestSuite
+	testEnv := s.NewTestActivityEnvironment()
+
+	run := &Run{}
+	testEnv.RegisterActivity(run.CallShellActivity)
+
+	task := &model.RunTask{
+		Run: model.RunTaskConfiguration{
+			Shell: &model.Shell{
+				Command: "sh",
+				Arguments: &model.RunArguments{
+					Value: []string{"-c", `printf "%s" "$OPENAI_API_KEY"`},
+				},
+				Environment: map[string]string{
+					"OPENAI_API_KEY": "${ $env.OPENAI_API_KEY }",
+				},
+			},
+		},
+	}
+
+	state := utils.NewState()
+	state.Env["OPENAI_API_KEY"] = "secret-key"
+
+	val, err := testEnv.ExecuteActivity(run.CallShellActivity, task, nil, state)
+	require.NoError(t, err)
+	require.True(t, val.HasValue())
+
+	var output string
+	require.NoError(t, val.Get(&output))
+	assert.Equal(t, "secret-key", output)
+}
+
+func TestInterpolateContainerConfigInterpolatesEnvironmentAndVolumes(t *testing.T) {
+	task := &model.RunTask{
+		Run: model.RunTaskConfiguration{
+			Container: &model.Container{
+				Image:   "${ $env.IMAGE }",
+				Command: "",
+				Environment: map[string]string{
+					"SERVICE_VALUE": "${ $env.SERVICE_VALUE }",
+				},
+				Volumes: map[string]interface{}{
+					"./tmp": "${ $env.CONTAINER_MOUNT }",
+				},
+				Arguments: []string{"${ $env.ARG_1 }"},
+			},
+		},
+	}
+
+	state := utils.NewState()
+	state.Env["IMAGE"] = "alpine:3.20"
+	state.Env["SERVICE_VALUE"] = "test-value"
+	state.Env["CONTAINER_MOUNT"] = "/workspace"
+	state.Env["ARG_1"] = "echo"
+
+	containerData, err := interpolateContainerConfig(task, state)
+	require.NoError(t, err)
+	require.NotNil(t, containerData)
+
+	envCmd := appendDockerEnvFlags([]string{"docker", "run"}, containerData["environment"])
+	assert.Contains(t, envCmd, "--env=SERVICE_VALUE=test-value")
+
+	volCmd, err := appendDockerVolumeFlags([]string{"docker", "run"}, containerData["volumes"])
+	require.NoError(t, err)
+	expectedLocal, err := filepath.Abs("./tmp")
+	require.NoError(t, err)
+	assert.Contains(t, volCmd, "--volume="+expectedLocal+":/workspace")
+}
+
+func TestDockerEntrypointFromInterpolated(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         any
+		expected      string
+		hasEntrypoint bool
+		wantErr       bool
+	}{
+		{
+			name:          "nil command is omitted",
+			value:         nil,
+			expected:      "",
+			hasEntrypoint: false,
+			wantErr:       false,
+		},
+		{
+			name:          "empty command is omitted",
+			value:         "",
+			expected:      "",
+			hasEntrypoint: false,
+			wantErr:       false,
+		},
+		{
+			name:          "non-empty command is used",
+			value:         "/bin/sh",
+			expected:      "/bin/sh",
+			hasEntrypoint: true,
+			wantErr:       false,
+		},
+		{
+			name:          "non-string command fails",
+			value:         123,
+			expected:      "",
+			hasEntrypoint: false,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entrypoint, hasEntrypoint, err := dockerEntrypointFromInterpolated(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, entrypoint)
+			assert.Equal(t, tt.hasEntrypoint, hasEntrypoint)
+		})
+	}
+}
+
+func TestDockerImageFromInterpolated(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:    "nil image fails",
+			value:   nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty image fails",
+			value:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace image fails",
+			value:   "   ",
+			wantErr: true,
+		},
+		{
+			name:     "valid image passes",
+			value:    "alpine:3.20",
+			expected: "alpine:3.20",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			image, err := dockerImageFromInterpolated(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, image)
+		})
+	}
+}
+
+func TestDockerArgsFromInterpolated(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name:     "nil arguments returns empty",
+			value:    nil,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:     "string slice passes through",
+			value:    []string{"echo", "hello"},
+			expected: []string{"echo", "hello"},
+			wantErr:  false,
+		},
+		{
+			name:     "any slice is stringified",
+			value:    []any{"echo", 7, true},
+			expected: []string{"echo", "7", "true"},
+			wantErr:  false,
+		},
+		{
+			name:    "nil argument fails fast",
+			value:   []any{"echo", nil},
+			wantErr: true,
+		},
+		{
+			name:    "non-array arguments fail",
+			value:   "echo",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, err := dockerArgsFromInterpolated(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, args)
+		})
+	}
+}


### PR DESCRIPTION
### Description
---
Ensure run task environment values resolve expressions like ${ $env.API_KEY } instead of being passed as literal strings.

Add regression coverage in runtime expression traversal and run activity tests for shell env interpolation.

### Related Issue(s)
---
Fixes: [#341](https://github.com/zigflow/zigflow/issues/341
)