### PR TITLE
feat(run): add --temporal-server-name flag for TLS SNI override

### DIFF
--- a/cmd/run/command.go
+++ b/cmd/run/command.go
@@ -49,8 +49,9 @@ type runOptions struct {
 	TemporalAPIKey                         string
 	TemporalMTLSCertPath                   string
 	TemporalMTLSKeyPath                    string
-	TemporalTLSEnabled                     bool
 	TemporalNamespace                      string
+	TemporalServerName                     string
+	TemporalTLSEnabled                     bool
 	Validate                               bool
 	Watch                                  bool
 	WatchDebounce                          time.Duration

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -86,6 +86,13 @@ func registerTemporalConnectionFlags(cmd *cobra.Command, opts *runOptions) {
 		viper.GetString("temporal_namespace"), "Temporal namespace to use",
 	)
 
+	cmd.Flags().StringVar(
+		&opts.TemporalServerName, "temporal-server-name",
+		viper.GetString("temporal_server_name"),
+		"Override the TLS server name (SNI) used for certificate validation. "+
+			"Required when the endpoint address does not match the certificate hostname, for example AWS PrivateLink.",
+	)
+
 	cmd.Flags().BoolVar(
 		&opts.TemporalTLSEnabled, "temporal-tls",
 		viper.GetBool("temporal_tls"), "Enable TLS Temporal connection",

--- a/cmd/run/flags_test.go
+++ b/cmd/run/flags_test.go
@@ -31,6 +31,7 @@ func TestNewRunCmd_Flags(t *testing.T) {
 	assert.NotNil(t, cmd.Flags().Lookup("validate"))
 	assert.NotNil(t, cmd.Flags().Lookup("temporal-address"))
 	assert.NotNil(t, cmd.Flags().Lookup("temporal-namespace"))
+	assert.NotNil(t, cmd.Flags().Lookup("temporal-server-name"))
 	assert.NotNil(t, cmd.Flags().Lookup("codec-endpoint"))
 	assert.NotNil(t, cmd.Flags().Lookup("codec-headers"))
 	assert.NotNil(t, cmd.Flags().Lookup("convert-data"))
@@ -44,6 +45,34 @@ func TestNewRunCmd_Flags(t *testing.T) {
 	assert.NotNil(t, cmd.Flags().Lookup("max-concurrent-activity-execution-size"))
 	assert.NotNil(t, cmd.Flags().Lookup("max-concurrent-workflow-task-execution-size"))
 	assert.NotNil(t, cmd.Flags().Lookup("task-queue-activities-per-second"))
+}
+
+// ---- --temporal-server-name flag ----
+
+func TestNewRunCmd_TemporalServerNameFlag(t *testing.T) {
+	cmd := New(func() *telemetry.Telemetry { return nil })
+
+	flag := cmd.Flags().Lookup("temporal-server-name")
+	require.NotNil(t, flag)
+	assert.Equal(t, "", flag.DefValue)
+}
+
+func TestNewRunCmd_TemporalServerNameFlagBoundToOpts(t *testing.T) {
+	cmd := New(func() *telemetry.Telemetry { return nil })
+
+	require.NoError(t, cmd.Flags().Set("temporal-server-name", "my-namespace.tmprl.cloud"))
+
+	flag := cmd.Flags().Lookup("temporal-server-name")
+	assert.Equal(t, "my-namespace.tmprl.cloud", flag.Value.String())
+}
+
+func TestNewRunCmd_TemporalServerNameFlagDefaultIsEmpty(t *testing.T) {
+	cmd := New(func() *telemetry.Telemetry { return nil })
+
+	flag := cmd.Flags().Lookup("temporal-server-name")
+	require.NotNil(t, flag)
+	// When omitted the flag is empty so existing connection behaviour is unchanged.
+	assert.Equal(t, "", flag.Value.String())
 }
 
 // ---- --watch flags ----

--- a/cmd/run/workers.go
+++ b/cmd/run/workers.go
@@ -31,6 +31,11 @@ import (
 	"go.temporal.io/sdk/worker"
 )
 
+// newTemporalConnection is the function used to establish a Temporal client. It
+// is a package-level variable so tests can substitute a test double without
+// spinning up a real Temporal server.
+var newTemporalConnection = temporal.NewConnection
+
 // runScheduleUpdates updates Temporal schedules for all workflow registrations
 // before any worker is started.
 func runScheduleUpdates(
@@ -192,10 +197,10 @@ func initTemporalClient(opts *runOptions) (client.Client, error) {
 	}
 
 	log.Trace().Msg("Connecting to Temporal")
-	tc, err := temporal.NewConnection(
+	tc, err := newTemporalConnection(
 		temporal.WithHostPort(opts.TemporalAddress),
 		temporal.WithNamespace(opts.TemporalNamespace),
-		temporal.WithTLS(opts.TemporalTLSEnabled),
+		temporal.WithTLS(opts.TemporalTLSEnabled, temporal.WithTLSServerName(opts.TemporalServerName)),
 		temporal.WithAuthDetection(
 			opts.TemporalAPIKey,
 			opts.TemporalMTLSCertPath,

--- a/cmd/run/workers_test.go
+++ b/cmd/run/workers_test.go
@@ -19,9 +19,98 @@ package run
 import (
 	"testing"
 
+	"github.com/mrsimonemms/golang-helpers/temporal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zigflow/zigflow/pkg/codec"
+	"go.temporal.io/sdk/client"
 )
+
+// applyOptions applies a slice of temporal.Options to a fresh client.Options
+// and returns the result. Each option is applied inside a deferred recover so
+// that options which register global HTTP handlers (e.g. Prometheus) do not
+// panic when called more than once across tests. TLS options are pure
+// in-memory and always succeed.
+func applyOptions(options []temporal.Options) client.Options {
+	opts := &client.Options{}
+	for _, o := range options {
+		func() {
+			defer func() { _ = recover() }()
+			_ = o(opts)
+		}()
+	}
+	return *opts
+}
+
+// stubTemporalConnection replaces newTemporalConnection with a test double that
+// captures the options it receives. It returns a restore function that must be
+// deferred by the caller.
+func stubTemporalConnection(captured *client.Options, called *bool) func() {
+	original := newTemporalConnection
+	newTemporalConnection = func(options ...temporal.Options) (client.Client, error) {
+		*called = true
+		*captured = applyOptions(options)
+		return nil, nil
+	}
+	return func() { newTemporalConnection = original }
+}
+
+// ---- initTemporalClient: TLS server name propagation ----
+
+func TestInitTemporalClient_ServerNamePropagation(t *testing.T) {
+	tests := []struct {
+		name           string
+		tlsEnabled     bool
+		serverName     string
+		expectTLSBlock bool
+		expectSNI      string
+	}{
+		{
+			name:           "server name is propagated when TLS is enabled",
+			tlsEnabled:     true,
+			serverName:     "your-namespace.tmprl.cloud",
+			expectTLSBlock: true,
+			expectSNI:      "your-namespace.tmprl.cloud",
+		},
+		{
+			name:           "empty server name leaves SNI unset when TLS is enabled",
+			tlsEnabled:     true,
+			serverName:     "",
+			expectTLSBlock: true,
+			expectSNI:      "",
+		},
+		{
+			name:           "no TLS block when TLS is disabled, even with server name set",
+			tlsEnabled:     false,
+			serverName:     "your-namespace.tmprl.cloud",
+			expectTLSBlock: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var captured client.Options
+			called := false
+			defer stubTemporalConnection(&captured, &called)()
+
+			opts := &runOptions{
+				TemporalTLSEnabled: test.tlsEnabled,
+				TemporalServerName: test.serverName,
+			}
+
+			_, err := initTemporalClient(opts)
+			require.NoError(t, err)
+			require.True(t, called, "newTemporalConnection was not invoked")
+
+			if test.expectTLSBlock {
+				require.NotNil(t, captured.ConnectionOptions.TLS, "expected TLS config to be set")
+				assert.Equal(t, test.expectSNI, captured.ConnectionOptions.TLS.ServerName)
+			} else {
+				assert.Nil(t, captured.ConnectionOptions.TLS, "expected no TLS config")
+			}
+		})
+	}
+}
 
 func TestBuildWorkersByTaskQueue(t *testing.T) {
 	tests := []struct {

--- a/docs/docs/deployment/intro.md
+++ b/docs/docs/deployment/intro.md
@@ -96,6 +96,7 @@ All deployment methods share the same connection flags:
 | `--temporal-namespace` | `TEMPORAL_NAMESPACE` | `default` | Temporal namespace |
 | `--temporal-tls` | `TEMPORAL_TLS` | `false` | Enable TLS. Required when connecting to Temporal Cloud |
 | `--temporal-api-key` | `TEMPORAL_API_KEY` | (none) | API key for Temporal Cloud |
+| `--temporal-server-name` | `TEMPORAL_SERVER_NAME` | (none) | Override the TLS server name for SNI and certificate validation |
 | `--tls-client-cert-path` | `TEMPORAL_TLS_CLIENT_CERT_PATH` | (none) | Path to mTLS client certificate |
 | `--tls-client-key-path` | `TEMPORAL_TLS_CLIENT_KEY_PATH` | (none) | Path to mTLS client key |
 
@@ -133,6 +134,29 @@ zigflow run \
   --tls-client-cert-path /path/to/cert \
   --tls-client-key-path /path/to/key
 ```
+
+### Private connectivity (AWS PrivateLink, VPC endpoints)
+
+When connecting to Temporal Cloud through a VPC endpoint or AWS PrivateLink, the
+dial address (for example `vpce-*.amazonaws.com:7233`) does not match the
+hostname on the Temporal Cloud certificate (for example `*.tmprl.cloud`). TLS
+validation will fail unless you tell Zigflow which hostname to validate against.
+
+Use `--temporal-server-name` to set the expected certificate hostname independently
+of the dial address:
+
+```sh
+zigflow run \
+  -f workflow.yaml \
+  --temporal-address vpce-0123456789abcdef0.vpce-svc-0123456789abcdef0.us-east-1.vpce.amazonaws.com:7233 \
+  --temporal-namespace your-namespace \
+  --temporal-tls \
+  --temporal-server-name your-namespace.tmprl.cloud \
+  --temporal-api-key your-api-key
+```
+
+`--temporal-server-name` only takes effect when `--temporal-tls` is also set.
+When omitted, the server name is derived from the dial address as normal.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/jsonschema-go v0.4.2
 	github.com/itchyny/gojq v0.12.19
 	github.com/matthewmueller/glob v0.1.1
-	github.com/mrsimonemms/golang-helpers v0.6.0
+	github.com/mrsimonemms/golang-helpers v0.6.1
 	github.com/mrsimonemms/temporal-codec-server/packages/golang v0.0.0-20260216220812-efae704c32dc
 	github.com/nexus-rpc/sdk-go v0.6.0
 	github.com/posthog/posthog-go v1.11.2

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mrsimonemms/golang-helpers v0.6.0 h1:MwX0AQjD8598EvWxCdSlkS9jHHEI3lHivLErx7hNBow=
-github.com/mrsimonemms/golang-helpers v0.6.0/go.mod h1:YkaFTvGtLb1U8W4DQC9MrnBxTTFL3cajUNWAI5yY8bI=
+github.com/mrsimonemms/golang-helpers v0.6.1 h1:+tmmXinZyp9JxRfxfmdi6T9b1LPXbUyc9hIbfjterRo=
+github.com/mrsimonemms/golang-helpers v0.6.1/go.mod h1:YkaFTvGtLb1U8W4DQC9MrnBxTTFL3cajUNWAI5yY8bI=
 github.com/mrsimonemms/temporal-codec-server/packages/golang v0.0.0-20260216220812-efae704c32dc h1:n53V1AA31gDA3o+hoyl7ZMRnpZSofiRIV2IVhjWAM9A=
 github.com/mrsimonemms/temporal-codec-server/packages/golang v0.0.0-20260216220812-efae704c32dc/go.mod h1:rKdqSHa7xT4ly0nhnzsbQEOEHSpOgynK9Xaz/uqFaIk=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds `--temporal-server-name` (viper: temporal_server_name) to allow overriding the TLS server name (SNI) used for certificate validation.

This is required when connecting to Temporal Cloud via private connectivity (for example AWS PrivateLink), where the dial address (`vpce-*.amazonaws.com`) does not match the certificate hostname (`*.tmprl.cloud`).

The value is passed through to golang-helpers ([v0.6.1](https://github.com/mrsimonemms/golang-helpers/releases/tag/v0.6.1)) via `temporal.WithTLSServerName`, preserving the existing connection setup including metrics and logging. When unset, behaviour remains unchanged.

Includes CLI flag registration, tests, and documentation updates covering the private connectivity use case.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #353

## How to test
<!-- Provide steps to test this PR -->
